### PR TITLE
Allow arrays of primitive types to be returned

### DIFF
--- a/custom-standards/Flyeralarm/Sniffs/Docblock/ReturnTypeSniff.php
+++ b/custom-standards/Flyeralarm/Sniffs/Docblock/ReturnTypeSniff.php
@@ -16,6 +16,10 @@ class ReturnTypeSniff implements Sniff
         'string',
         'float',
         'array',
+        'bool[]',
+        'int[]',
+        'string[]',
+        'float[]', 
         'null'
     ];
 


### PR DESCRIPTION
 Example (currently marked as incorrect) code   
   /**
     * @param string $param
     * @return string[]
     */
    public function getAllUploadedFilePaths(string $param): array
    {
        $search = sprintf(...);
        $files = glob($search);

        return $files;
    }
