### PR TITLE
Allow mysqli, mysqli_driver, mysqli_result, mysqli_stmt, mysqli_sql_e…

### DIFF
--- a/custom-standards/Flyeralarm/Sniffs/Docblock/ReturnTypeSniff.php
+++ b/custom-standards/Flyeralarm/Sniffs/Docblock/ReturnTypeSniff.php
@@ -20,8 +20,20 @@ class ReturnTypeSniff implements Sniff
         'bool[]',
         'int[]',
         'string[]',
-        'float[]', 
+        'float[]',
         'null'
+    ];
+
+    /**
+     * @var array
+     */
+    private $returnTypeClassWhitelist = [
+        'mysqli',
+        'mysqli_driver',
+        'mysqli_result',
+        'mysqli_stmt',
+        'mysqli_sql_exception',
+        'mysqli_warning',
     ];
 
     /**
@@ -50,7 +62,10 @@ class ReturnTypeSniff implements Sniff
 
         foreach ($returnTypes as $returnType) {
             $returnType = trim($returnType);
-            if (in_array($returnType, $this->returnTypeScalarWhitelist)) {
+            if (in_array($returnType, $this->returnTypeScalarWhitelist, true)) {
+                continue;
+            }
+            if (in_array($returnType, $this->returnTypeClassWhitelist, true)) {
                 continue;
             }
             if ($this->isStartingWithUppercaseLetter($returnType)) {

--- a/tests/rules/doc/allowed/ReturnTypeMysqli.php
+++ b/tests/rules/doc/allowed/ReturnTypeMysqli.php
@@ -1,0 +1,50 @@
+<?php
+
+// @expectedPass
+
+namespace flyeralarm\Test;
+
+class FooTest
+{
+    /**
+     * @return mysqli
+     */
+    public function testMysqli()
+    {
+    }
+
+    /**
+     * @return mysqli_driver
+     */
+    public function testMysqliDriver()
+    {
+    }
+
+    /**
+     * @return mysqli_result
+     */
+    public function testMysqliResult()
+    {
+    }
+
+    /**
+     * @return mysqli_stmt
+     */
+    public function testMysqliStmt()
+    {
+    }
+
+    /**
+     * @return mysqli_sql_exception
+     */
+    public function testMysqliSqlException()
+    {
+    }
+
+    /**
+     * @return mysqli_warning
+     */
+    public function testMysqliWarning()
+    {
+    }
+}


### PR DESCRIPTION
Not capitalized classes (such as the mysqli* classes) are mistakenly interpreted as scalar types and Code Sniffer will fail on those.

Added the mysqli* classes as valid return types to the custom standards.