### PR TITLE
Support Phpstan array generics

### DIFF
--- a/custom-standards/Flyeralarm/Sniffs/Docblock/ReturnTypeSniff.php
+++ b/custom-standards/Flyeralarm/Sniffs/Docblock/ReturnTypeSniff.php
@@ -160,6 +160,11 @@ class ReturnTypeSniff implements Sniff
                 }
 
                 $match = trim($match);
+                if (strpos($match, 'int,') === 0) {
+                    // Allow numeric indexing in generics, e.g. `array<int, string>`
+                    $match = substr($match, 4);
+                }
+
                 if ($match === '') {
                     throw new \InvalidArgumentException('Generic specification may not be empty in type "' . $matches[0][$index] . '"');
                 }

--- a/custom-standards/Flyeralarm/Sniffs/Docblock/ReturnTypeSniff.php
+++ b/custom-standards/Flyeralarm/Sniffs/Docblock/ReturnTypeSniff.php
@@ -143,9 +143,9 @@ class ReturnTypeSniff implements Sniff
      */
     private function checkReturnTypeShape(string $subject)
     {
-        preg_match_all('#(?<separator>\s*\|\s*)?(?<atom>[^<>\|]+)(?<generic><(?<nested>.*)>)?#', $subject, $matches);
+        $matched = preg_match_all('#(?<separator>\s*\|\s*)?(?<atom>[^<>\|]+)(?<generic><(?<nested>.*)>)?#', $subject, $matches);
 
-        if (implode('', $matches[0]) !== $subject) {
+        if (!$matched || implode('', $matches[0]) !== $subject) {
             throw new \InvalidArgumentException('Invalid structure in return type "' . $subject . '"');
         }
 

--- a/custom-standards/Flyeralarm/Sniffs/Docblock/ReturnTypeSniff.php
+++ b/custom-standards/Flyeralarm/Sniffs/Docblock/ReturnTypeSniff.php
@@ -154,7 +154,7 @@ class ReturnTypeSniff implements Sniff
         }
 
         foreach ($matches['nested'] as $index => $match) {
-            if (!empty($matches['generic'][$index])) {
+            if ($matches['generic'][$index] === '') {
                 if (trim($matches['atom'][$index]) !== 'array') {
                     throw new \InvalidArgumentException('Unexpected generic specification in type "' . $matches[0][$index] . '"');
                 }

--- a/tests/rules/doc/allowed/ReturnTypeArrayGenerics.php
+++ b/tests/rules/doc/allowed/ReturnTypeArrayGenerics.php
@@ -21,6 +21,13 @@ class FooTest
     }
 
     /**
+     * @return array<int, string>
+     */
+    public function testWithNumericIndex()
+    {
+    }
+
+    /**
      * @return array<string | int>
      */
     public function testWithAlternativeInside()

--- a/tests/rules/doc/allowed/ReturnTypeArrayGenerics.php
+++ b/tests/rules/doc/allowed/ReturnTypeArrayGenerics.php
@@ -1,0 +1,50 @@
+<?php
+
+// @expectedPass
+
+namespace flyeralarm\Test;
+
+class FooTest
+{
+    /**
+     * @return array
+     */
+    public function testArray()
+    {
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function testWithGeneric()
+    {
+    }
+
+    /**
+     * @return array<string | int>
+     */
+    public function testWithAlternativeInside()
+    {
+    }
+
+    /**
+     * @return int | array<array<string>>
+     */
+    public function testWithAlternativeOutside()
+    {
+    }
+
+    /**
+     * @return array<array<string>> | null
+     */
+    public function testWithAlternativeAtTheEnd()
+    {
+    }
+
+    /**
+     * @return int | array<string | array<string>>
+     */
+    public function testWithMultipleAlternatives()
+    {
+    }
+}

--- a/tests/rules/doc/not-allowed/EmptyAlternativeInReturnTypeInDocComment.php
+++ b/tests/rules/doc/not-allowed/EmptyAlternativeInReturnTypeInDocComment.php
@@ -1,0 +1,14 @@
+<?php
+
+// @expectedError Missing return type in first alternative of type "| string"
+
+class EmptyAlternativeInReturnTypeInDocComment
+{
+    /**
+     * @return | string
+     */
+    public function foo()
+    {
+        return true;
+    }
+}

--- a/tests/rules/doc/not-allowed/EmptyGenericReturnTypeInDocComment.php
+++ b/tests/rules/doc/not-allowed/EmptyGenericReturnTypeInDocComment.php
@@ -1,0 +1,14 @@
+<?php
+
+// @expectedError Generic specification may not be empty in type "array<>"
+
+class EmptyGenericReturnTypeInDocComment
+{
+    /**
+     * @return array<>
+     */
+    public function foo()
+    {
+        return true;
+    }
+}

--- a/tests/rules/doc/not-allowed/InvalidStructureInReturnTypeInDocComment.php
+++ b/tests/rules/doc/not-allowed/InvalidStructureInReturnTypeInDocComment.php
@@ -1,0 +1,14 @@
+<?php
+
+// @expectedError Invalid structure in return type "array<int"
+
+class InvalidStructureInReturnTypeInDocComment
+{
+    /**
+     * @return array<int
+     */
+    public function foo()
+    {
+        return true;
+    }
+}

--- a/tests/rules/doc/not-allowed/MissingAlternativeSeparatorInReturnTypeInDocComment.php
+++ b/tests/rules/doc/not-allowed/MissingAlternativeSeparatorInReturnTypeInDocComment.php
@@ -1,0 +1,14 @@
+<?php
+
+// @expectedError Return type "array int" is discouraged
+
+class MissingAlternativeSeparatorInReturnTypeInDocComment
+{
+    /**
+     * @return array int
+     */
+    public function foo()
+    {
+        return true;
+    }
+}

--- a/tests/rules/doc/not-allowed/UnknownGenericReturnTypeInDocComment.php
+++ b/tests/rules/doc/not-allowed/UnknownGenericReturnTypeInDocComment.php
@@ -1,0 +1,14 @@
+<?php
+
+// @expectedError Unexpected generic specification in type "int<array>"
+
+class UnknownGenericReturnTypeInDocComment
+{
+    /**
+     * @return int<array>
+     */
+    public function foo()
+    {
+        return true;
+    }
+}

--- a/tests/rules/doc/not-allowed/UnknownGenericSubReturnTypeInDocComment.php
+++ b/tests/rules/doc/not-allowed/UnknownGenericSubReturnTypeInDocComment.php
@@ -1,0 +1,14 @@
+<?php
+
+// @expectedError Return type "foo" is discouraged
+
+class UnknownGenericSubReturnTypeInDocComment
+{
+    /**
+     * @return array<foo>
+     */
+    public function foo()
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
This as support for typehinting in array return types as described in #21. It doesn't add support for array shapes like `array{foo: int, bar: string}`, which is also supported by PHPStan. But it's enough to allow both tools to work together on a project.