### PR TITLE
IN-1729 - Add GitHub workflow for php projects with tests

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,0 +1,42 @@
+name: PHP Composer
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Versions
+      run: php --version && composer --version
+
+    - name: Validate composer.json and composer.lock
+      run: composer validate --strict
+
+    - name: Cache Composer packages
+      id: composer-cache
+      uses: actions/cache@v3
+      with:
+        path: vendor
+        key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-php-
+
+    - name: Install dependencies
+      run: composer install --prefer-dist --no-progress
+
+    - name: phpcs version
+      run: vendor/bin/phpcs --version
+
+    - name: Run test suite
+      run: php tests/runner.php

--- a/tests/runner.php
+++ b/tests/runner.php
@@ -23,7 +23,7 @@ function processDir($dirPath)
         $fileContent = file_get_contents($dirPath . $file);
         $snifferOutput = shell_exec(
             sprintf(
-                "%s -w -p -s --standard=%s %s",
+                "%s -w -p -s --report-width=120 --standard=%s %s",
                 escapeshellcmd(__DIR__ . '/../vendor/bin/phpcs'),
                 escapeshellarg(__DIR__ . '/ruleset.xml'),
                 escapeshellarg($dirPath . $file)


### PR DESCRIPTION
- Run tests in CI on PR
- Set report width to be wide enough in order not to break error message to a multi-line which was breaking tests as they are scraping from stdout