### PR TITLE
remove obsolete bin/php-code-validator from composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,5 @@
     "minimum-stability": "stable",
     "require": {
         "squizlabs/php_codesniffer": "^3.5"
-    },
-    "bin": [
-        "bin/php-code-validator"
-    ]
+    }
 }


### PR DESCRIPTION
the script bin/php-code-validator got removed with the latest version so we shouldn't include it in composer.json anymore