### PR TITLE
Update PHP_CodeSniffer to 3.13.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PHP_IMAGE_TAG=flyeralarm/php-code-valiator-cli:$(PHP_VERSION)
+PHP_IMAGE_TAG=flyeralarm/php-code-validator:$(PHP_VERSION)
 PHP_VERSION?=8.3
 
 PHP_BIN=$(RUNNER) php
@@ -40,6 +40,7 @@ test:
 
 .PHONY: test-all
 test-all:
+	PHP_VERSION=8.4 $(MAKE) build update sniff test
 	PHP_VERSION=8.3 $(MAKE) build update sniff test
 	PHP_VERSION=8.2 $(MAKE) build update sniff test
 	PHP_VERSION=8.1 $(MAKE) build update sniff test

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # FLYERALARM PHP Coding Guideline Validator
 
 This repository contains the ruleset for the PHP code we develop at [FLYERALARM](https://flyeralarm.com).
-It mostly consists of PSR-12 with some custom additions. The rules are enforced with the help of squizlabs/PHP_CodeSniffer
+It mostly consists of PSR-12 with some custom additions. The rules are enforced with the help of PHPCSStandards/PHP_CodeSniffer
 
 The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”,
 “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be
@@ -68,7 +68,7 @@ test:
 
 The recommended way to define custom rules for the own project is to provide a ```phpcs.xml``` in the root of your
 project.
-PHP_CodeSniffer will automatically detect this standard if no other standard was defined (See [PHP_CodeSniffer Advanced Usage](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#using-a-default-configuration-file)).
+PHP_CodeSniffer will automatically detect this standard if no other standard was defined (See [PHP_CodeSniffer Advanced Usage](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Advanced-Usage#using-a-default-configuration-file)).
 
 This ```phpcs.xml``` can then reference the FLYERALARM PHP coding standard.
 ```xml

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,6 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "squizlabs/php_codesniffer": "^3.5"
+        "phpcsstandards/php_codesniffer": "^3.5"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,6 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "phpcsstandards/php_codesniffer": "^3.5"
+        "squizlabs/php_codesniffer": "^3.5"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "080d10290401a21c793fa6e75486610a",
+    "content-hash": "a8e98f1dfefe257b62cae19d4f0eba37",
     "packages": [
         {
-            "name": "squizlabs/php_codesniffer",
-            "version": "3.11.1",
+            "name": "phpcsstandards/php_codesniffer",
+            "version": "3.13.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "19473c30efe4f7b3cd42522d0b2e6e7f243c6f87"
+                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/19473c30efe4f7b3cd42522d0b2e6e7f243c6f87",
-                "reference": "19473c30efe4f7b3cd42522d0b2e6e7f243c6f87",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
                 "shasum": ""
             },
             "require": {
@@ -34,11 +34,6 @@
                 "bin/phpcs"
             ],
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.x-dev"
-                }
-            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
@@ -82,9 +77,14 @@
                 {
                     "url": "https://opencollective.com/php_codesniffer",
                     "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
                 }
             ],
-            "time": "2024-11-16T12:02:36+00:00"
+            "abandoned": "squizlabs/php_codesniffer",
+            "time": "2025-11-04T16:30:35+00:00"
         }
     ],
     "packages-dev": [],
@@ -95,5 +95,5 @@
     "prefer-lowest": false,
     "platform": {},
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,10 +4,10 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a8e98f1dfefe257b62cae19d4f0eba37",
+    "content-hash": "080d10290401a21c793fa6e75486610a",
     "packages": [
         {
-            "name": "phpcsstandards/php_codesniffer",
+            "name": "squizlabs/php_codesniffer",
             "version": "3.13.5",
             "source": {
                 "type": "git",
@@ -83,7 +83,6 @@
                     "type": "thanks_dev"
                 }
             ],
-            "abandoned": "squizlabs/php_codesniffer",
             "time": "2025-11-04T16:30:35+00:00"
         }
     ],


### PR DESCRIPTION
This pull request updates the project to use the `PHPCSStandards/PHP_CodeSniffer` package instead of `squizlabs/PHP_CodeSniffer`, and makes related adjustments throughout the codebase. It also updates the Docker image reference and adds initial support for PHP 8.4 in the test matrix.

This closes #34 

Dependency and documentation updates:

* Switched the PHP CodeSniffer dependency from `squizlabs/php_codesniffer` to `phpcsstandards/php_codesniffer` in `composer.json`.
* Updated all documentation references in `README.md` from `squizlabs/PHP_CodeSniffer` to `PHPCSStandards/PHP_CodeSniffer`, including links and package names. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L4-R4) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L71-R71)

Build and testing changes:

* Changed the Docker image tag in the `Makefile` to use `flyeralarm/php-code-validator` instead of `flyeralarm/php-code-valiator-cli`.
* Added PHP 8.4 to the test matrix in the `Makefile`'s `test-all` target.